### PR TITLE
Maids Icon Fix

### DIFF
--- a/gamedata/configs/mod_system_artigrok_weapon_ammo_icons.ltx
+++ b/gamedata/configs/mod_system_artigrok_weapon_ammo_icons.ltx
@@ -1,0 +1,26 @@
+![ammo_7.62x25_p_bad]
+inv_grid_x = 58
+inv_grid_y = 9
+
+![ammo_7.62x25_ps]
+inv_grid_x = 60
+inv_grid_y = 8
+
+![ammo_9x39_pab9]
+inv_grid_y = 21
+
+![ammo_9x39_ap]
+inv_grid_y = 20
+
+![ammo_7.62x54_7h1]
+inv_grid_y = 31
+
+![ammo_7.62x54_7h1_bad]
+inv_grid_y = 31
+
+![ammo_7.62x54_7h14]
+inv_grid_y = 19
+
+![ammo_7.62x54_7h14_bad]
+inv_grid_y = 19
+

--- a/gamedata/configs/mod_system_zzzzzz_artigrok_weapon_ammo.ltx
+++ b/gamedata/configs/mod_system_zzzzzz_artigrok_weapon_ammo.ltx
@@ -103,8 +103,6 @@ inv_name_short = ammo_new_7.62x25_p_s
 
 ![ammo_7.62x25_p_bad]
 cost = 1345
-inv_grid_x = 58
-inv_grid_y = 9
 inv_name = ammo_new_7.62x25_hp
 inv_name_short = ammo_new_7.62x25_hp_s
 k_disp = 0.68
@@ -115,8 +113,6 @@ impair = 1.1
 k_cam_dispersion = 0.7
 
 ![ammo_7.62x25_ps]
-inv_grid_x = 60
-inv_grid_y = 8
 inv_name = ammo_new_7.62x25_ps
 inv_name_short = ammo_new_7.62x25_ps_s
 k_disp = 0.70
@@ -234,7 +230,6 @@ k_ap = 0.064
 !impair
 
 ![ammo_9x39_pab9]
-inv_grid_y = 21
 inv_name = ammo_new_9x39_sp5
 inv_name_short = ammo_new_9x39_sp5_s
 
@@ -247,7 +242,6 @@ k_ap = 0.0348
 !impair
 
 ![ammo_9x39_ap]
-inv_grid_y = 20
 inv_name = ammo_new_9x39_pab9
 inv_name_short = ammo_new_9x39_pab9_s
 
@@ -400,14 +394,12 @@ impair = 1.5
 buck_shot = 3
 
 ![ammo_7.62x54_7h1]
-inv_grid_y = 31
 inv_name = ammo_new_7.62x54_hp
 inv_name_short = ammo_new_7.62x54_hp_s
 k_hit = 1.18
 
 ![ammo_7.62x54_7h1_bad]
 cost = 52500
-inv_grid_y = 31
 inv_name = ammo_new_7.62x54_fp
 inv_name_short = ammo_new_7.62x54_fp_s
 k_hit = 1.117
@@ -443,13 +435,11 @@ inv_name_short = ammo_new_4.6x30_fmj_s
 inv_name_short = ammo_new_4.6x30_fmj_s
 
 ![ammo_7.62x54_7h14]
-inv_grid_y = 19
 inv_name = ammo_new_7.62x54r
 inv_name_short = ammo_new_7.62x54r_s
 
 ![ammo_7.62x54_7h14_bad]
 cost = 4800
-inv_grid_y = 19
 inv_name = ammo_new_7.62x54_7n1
 inv_name_short = ammo_new_7.62x54_7n1_s
 k_hit = 1.17


### PR DESCRIPTION
It was reported that the Maid's Icon pack mod was broken with some ammos with the recent release with 0.9, which also included the move to DLTX.

I was curious, and looked into it, and suspected that it was caused by the "mod_system_maidammo.ltx" file being overwritten, and testing with this fix appears to have proven that to be true.

I am submitting this PR as a simple-fix for re-adding compatibility with maidammo.

Some details listed in the Discord mod forum thread:
https://discord.com/channels/912320241713958912/1065168136577482753/1095763596585222276

The below screenshot is showing that the 7.62x25 PSt icon (as well as the 7.62x54 icons) missing, with the current release of Artigrok with Maid's Icon pack enabled:
![AnomalyDX11AVX_2023-04-12_19-12-17](https://user-images.githubusercontent.com/15268715/231605885-ba5ac1a5-8bfb-4dab-aabe-b3ebe12e515e.jpg)

The below screenshot is showing that the 7.62x25 PSt icon (as well as the 7.62x54 icons) is in-fact visible, with the modifications in this pull request:
![AnomalyDX11AVX_2023-04-12_18-56-20](https://user-images.githubusercontent.com/15268715/231605190-a5c01033-a084-449c-8d1a-210d41e71699.jpg)

EDIT: Fixed typo of "mode" -> "mod"